### PR TITLE
Update setBusy to avoid unnecessary reconstruction

### DIFF
--- a/014-provider-v3-updates/2-final/lib/core/viewmodels/base_model.dart
+++ b/014-provider-v3-updates/2-final/lib/core/viewmodels/base_model.dart
@@ -6,6 +6,6 @@ class BaseModel extends ChangeNotifier {
 
   void setBusy(bool value) {
     _busy = value;
-    notifyListeners();
+    _busy == false ? notifyListeners() : null;
   }
 }


### PR DESCRIPTION
From my point of view call _notifyListeners()_, when _setBusy(true)_ is a wasted, cause we  rebuild all the consummer with no actually new data.
 
```
 void setBusy(bool value) {
    _busy = value;
    notifyListeners();
    notifyListeners() ;
}
```

```
Future getPosts(int userId) async {
    setBusy(true); //notifyListeners() been call for not reason
    posts = await _api.getPostsForUser(userId);
    setBusy(false); //there is when we need notifyListeners() 
  }
```